### PR TITLE
s/Any::Moose/Moo/;

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,8 @@ author   'Andrew Chilton <andychilton@gmail.com>';
 repository 'https://github.com/catalyst/XML-Compare';
 
 requires        "XML::LibXML" => 1.58;  # oldest tested
-requires        "Any::Moose" => 0;
+requires        "Moo" => 2;             # so warnings are not fatal
+requires        "MooX::Types::MooseLike";
 
 build_requires 'Test::More';
 build_requires 'Test::Builder::Tester';

--- a/lib/XML/Compare.pm
+++ b/lib/XML/Compare.pm
@@ -3,11 +3,10 @@
 ## ----------------------------------------------------------------------------
 package XML::Compare;
 
-use XML::LibXML;
-use Any::Moose;
+use Moo;
+use MooX::Types::MooseLike::Base qw(Bool Str ArrayRef HashRef Undef);
 
-use strict;
-use warnings;
+use XML::LibXML;
 
 our $VERSION = '0.04';
 our $VERBOSE = $ENV{XML_COMPARE_VERBOSE} || 0;
@@ -44,13 +43,13 @@ my $has = {
 
 has 'namespace_strict' =>
     is => "rw",
-    isa => "Bool",
+    isa => Bool,
     default => 0,
     ;
 
 has 'error' =>
     is => "rw",
-    isa => "Str",
+    isa => Str,
     clearer => "_clear_error",
     ;
 
@@ -161,17 +160,17 @@ sub _are_docs_same {
 
 has 'ignore' =>
     is => "rw",
-    isa => "ArrayRef[Str]",
+    isa => ArrayRef[Str],
     ;
 
 has 'ignore_xmlns' =>
     is => "rw",
-    isa => "HashRef[Str]",
+    isa => HashRef[Str],
     ;
 
 has '_ignore_nodes' =>
     is => "rw",
-    isa => "HashRef[Undef]",
+    isa => HashRef[Undef],
     clearer => "_ignore_nothing",
     ;
 


### PR DESCRIPTION
Any::Moose is DEPRECATED. Migrate to Moo.

Want Moo v2 so as fatal warnings are handled the same way as Moose.

(Submitted as part of the CPAN PR Challenge).
